### PR TITLE
Fix bugs with Session DB Save Handler:

### DIFF
--- a/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
+++ b/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
@@ -337,8 +337,6 @@ class Zend_Session_SaveHandler_DbTable
      */
     public function write($id, $data)
     {
-        $return = false;
-
         $data = array($this->_modifiedColumn => time(),
                       $this->_dataColumn     => (string) $data);
 
@@ -346,36 +344,29 @@ class Zend_Session_SaveHandler_DbTable
 
         if (count($rows)) {
             $data[$this->_lifetimeColumn] = $this->_getLifetime($rows->current());
-
-            if ($this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-                $return = true;
-            }
+            $this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
+            return true;
         } else {
             $data[$this->_lifetimeColumn] = $this->_lifetime;
 
             if ($this->insert(array_merge($this->_getPrimary($id, self::PRIMARY_TYPE_ASSOC), $data))) {
-                $return = true;
+                return true;
             }
         }
 
-        return $return;
+        return false;
     }
 
     /**
      * Destroy session
      *
      * @param string $id
-     * @return boolean
+     * @return true
      */
     public function destroy($id)
     {
-        $return = false;
-
-        if ($this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-            $return = true;
-        }
-
-        return $return;
+        $this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
+        return true;
     }
 
     /**


### PR DESCRIPTION
- True is returned when updating the session, even if the session DB record was not actually updated.
- True is always returned when destroying the session, even if the session was already deleted from the DB.